### PR TITLE
Add regex to remove emojis from response

### DIFF
--- a/custom_components/openclaw_conversation/conversation.py
+++ b/custom_components/openclaw_conversation/conversation.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import Literal
 
 import aiohttp
-
 from homeassistant.components import conversation
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -23,6 +23,11 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+def strip_emoji(text: str) -> str:
+    # Regex to match most emoji characters
+    emoji_pattern = re.compile('[\U00010000-\U0010ffff]', flags=re.UNICODE)
+    return emoji_pattern.sub(r'', text)
 
 
 class OpenClawConversationAgent(conversation.AbstractConversationAgent):
@@ -66,6 +71,9 @@ class OpenClawConversationAgent(conversation.AbstractConversationAgent):
         except Exception as err:
             _LOGGER.error("Error calling OpenClaw: %s", err)
             response_text = "Erreur de communication avec OpenClaw."
+
+        # Strip (most) emojis
+        response_text = strip_emoji(response_text)
 
         # Add assistant response to history
         messages.append({"role": "assistant", "content": response_text})


### PR DESCRIPTION
Just a simple implementation to remove emojis from the openclaw response.

I've tried adding a setting to add a prompt like "do not use emojis", but looks like system messages get overwritten by openclaw, so the fallback is to strip them from the response. 

Probably not an optimal solution, but it works and can be improved in the future.